### PR TITLE
Give the footer logo a themed tile background

### DIFF
--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -9,7 +9,7 @@ export default function SiteFooter() {
     <footer className="border-t px-6 text-sm">
       <div className="mx-auto flex h-12 w-full max-w-[644px] items-center justify-between text-muted-foreground/80">
         <span className="mr-2 flex items-center gap-2.5">
-          <Logo variant="mark" size={13} className="shrink-0" />
+          <Logo variant="tile" size={16} className="shrink-0" />
           Embrace Minimalism.
         </span>
         <div className="flex items-center space-x-4">


### PR DESCRIPTION
## What

`SiteFooter` rendered `<Logo variant="mark" />` — the bare letterform, which has no background at all. It swapped colour with the theme (a dark R on light, a light R on dark), but there was no tile behind it either way.

Switched to `variant="tile"`, which draws the squircle with the R knocked out:

- **Light theme** → dark tile, light R showing through
- **Dark theme** → light tile, dark R showing through

## Why it needs no colour code

The tile paints with `currentColor`, inherited from the footer row's `text-muted-foreground/80`, so the inversion falls out of the existing theme tokens. No `dark:` variant, no second asset, no `useTheme()` — and therefore no hydration flash.

## The size bump

13 → 16px. The glyph ink box is 56 units of a 100 box, so a 13px tile renders the R at roughly 7px — and as a *knockout* rather than positive ink, which `CLAUDE.md` already notes needs extra weight to hold up. It turned to mush. 16px keeps it legible and matches the optical weight the 13px mark had next to the 14px footer text.

## Verification

Ran the dev server and checked the footer in both themes via the theme toggle — dark tile with a light R in light mode, light tile with a dark R in dark mode.

`pnpm lint` passes clean.

`pnpm typecheck` reports one **pre-existing, unrelated** failure:

```
src/lib/db.ts(3,30): error TS2307: Cannot find module '@/generated/prisma/client'
```

The generated client is gitignored and `pnpm prisma generate` can't run in a fresh worktree without a `.env` — `prisma.config.ts` resolves `env()` eagerly and fails with `Cannot resolve environment variable: DATABASE_URL`. Nothing to do with this diff; it reproduces on a clean checkout of `main`.

## Reviewer note

One-line diff, but it does change the footer's visual weight — the logo goes from a hairline letterform to a small solid block. Worth an eyeball rather than a rubber stamp if the minimal footer look is deliberate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)